### PR TITLE
Removed send from send_email

### DIFF
--- a/api/email_helper.py
+++ b/api/email_helper.py
@@ -10,22 +10,28 @@ def send_email(body, subject=f'ERROR LOG [{datetime.strftime(datetime.now(), "%b
     """
     Sends an email with the subject formatted as 'ERROR LOG [Jan 01, 1970 - 12:00 AM]'
     """
-    def send():
-        from_ = EMAIL_CONFIG['FROM']
-        to = EMAIL_CONFIG['TO']
-
-        msg = MIMEMultipart()
-        msg['From'] = from_
-        msg['To'] = to
-        msg['Subject'] = subject
-        msg.attach(MIMEText(body, 'plain'))
-        server = smtplib.SMTP(EMAIL_CONFIG['HOST'], EMAIL_CONFIG['PORT'])
-        server.starttls()
-        server.login(from_, EMAIL_CONFIG['PASSWORD'])
-        server.sendmail(from_, to, msg.as_string())
-        server.quit()
 
     # Send the email on a separate thread so the server doesn't
     # have to wait for it to finish
-    thread = Thread(target=send)
+    thread = Thread(target=_send, args=(body, subject))
     thread.start()
+
+
+def _send(body, subject):
+    from_ = EMAIL_CONFIG['FROM']
+    to = EMAIL_CONFIG['TO']
+
+    msg = MIMEMultipart()
+    msg['From'] = from_
+    msg['To'] = to
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+    server = smtplib.SMTP(EMAIL_CONFIG['HOST'], EMAIL_CONFIG['PORT'])
+    server.starttls()
+    server.login(from_, EMAIL_CONFIG['PASSWORD'])
+
+    senders = server.sendmail(from_, to, msg.as_string())
+
+    server.quit()
+
+    return senders


### PR DESCRIPTION
`_send` now returns a `dict` with one entry for each recipient that was refused.

Fixes #1